### PR TITLE
Add support for Emotion

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -16,11 +16,14 @@ let dc_import_line = search('import\(.\|\n\)*from.*diet-cola', 'n')
 let dc_require_line = search('require\(.\|\n\)*diet-cola', 'n')
 let gl_import_line = search('import\(.\|\n\)*from.*glamor\/styled', 'n')
 let gl_require_line = search('require\(.\|\n\)*glamor\/styled', 'n')
+let em_import_line = search('import\(.\|\n\)*from.*emotion', 'n')
+let em_require_line = search('require\(.\|\n\)*emotion', 'n')
 
 " if there is such a line in the document
 if sc_import_line > 0 || sc_require_line > 0 ||
       \ dc_import_line > 0 || dc_require_line > 0 ||
-      \ gl_import_line > 0 || gl_require_line > 0
+      \ gl_import_line > 0 || gl_require_line > 0 ||
+      \ em_import_line > 0 || em_require_line > 0
 
   " extend javascript syntax
   runtime! syntax/css.vim


### PR DESCRIPTION
Hello! Thanks for the plugin. This is a tiny PR to add support for [Emotion](https://github.com/tkh44/emotion), since it uses essentially the same signature as styled-components and similar.

I’ve tested this locally (macOS, NeoVim 0.2.0) to ensure syntax highlighting and indentation work as expected.

![image](https://user-images.githubusercontent.com/1713932/29575056-4205e0d4-875b-11e7-9938-2ef81ab122b7.png)
