### PR TITLE
Update installation instructions for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install via:
 
 Add to vimrc:
 
-    Plug 'styled-components/vim-styled-components'
+    Plug 'styled-components/vim-styled-components', { 'branch': 'main' }
 
 Install via:
 


### PR DESCRIPTION
Vim-plug (unlike the alternatives) provides 'master' as the default
branch name, which is not the case with this plugin.

This commit updates the installation instructions for this plugin manager.