### PR TITLE
Add support for css.resolve and css.global from styled-jsx

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -176,7 +176,7 @@ syn match cssError contained "{@<>"
 
 " extend javascript matches to trigger styledDefinition highlighting
 syn match jsTaggedTemplate extend
-      \ "\<css\>\|\<keyframes\>\|\<injectGlobal\>\|\<fontFace\>\|\<createGlobalStyle\>"
+      \ "\<css\>\|\.\<resolve\>\|\.\<global\>\|\<keyframes\>\|\<injectGlobal\>\|\<fontFace\>\|\<createGlobalStyle\>"
       \ nextgroup=styledDefinition
 syn match jsFuncCall "\<styled\>\s*(.\+)" transparent
       \ nextgroup=styledDefinition

--- a/examples/issue-67.js
+++ b/examples/issue-67.js
@@ -1,0 +1,11 @@
+const body = css.global`
+  body {
+    margin: 0;
+  }
+`;
+
+const link = css.resolve`
+  a {
+    color: green;
+  }
+`;


### PR DESCRIPTION
Hi,
I added the support for `css.resolve` and `css.global` from [styled-jsx](https://www.npmjs.com/package/styled-jsx#external-css-and-styles-outside-of-the-component). Fix #67.
Hope this is ok.
Have a nice day.