### PR TITLE
Fix way to include CSS3 syntax fo neovim

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -20,7 +20,12 @@ syn include @CSS syntax/css.vim
 
 " try to include CSS3 definitions from multiple files
 " this is only possible on vim version above 7
-if v:version >= 700
+if has('nvim')
+  try
+    syn include @CSS3 syntax/css.vim
+  catch
+  endtry
+elseif v:version >= 700
   try
     syn include @CSS3 syntax/css/*.vim
   catch


### PR DESCRIPTION
Neovim does have different folder structure. I'm not sure is this make sense? Otherwise I'm gonna make other commit to disable for neovim totally.