### PR TITLE
Limiting the scope of plugin files.

### DIFF
--- a/after/ftplugin/javascriptreact.vim
+++ b/after/ftplugin/javascriptreact.vim
@@ -1,1 +1,1 @@
-runtime! ftplugin/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/ftplugin/typescript.vim
+++ b/after/ftplugin/typescript.vim
@@ -1,1 +1,1 @@
-runtime! ftplugin/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/ftplugin/typescriptreact.vim
+++ b/after/ftplugin/typescriptreact.vim
@@ -1,1 +1,1 @@
-runtime! ftplugin/typescript.vim
+source <sfile>:p:h/typescript.vim

--- a/after/indent/javascriptreact.vim
+++ b/after/indent/javascriptreact.vim
@@ -1,1 +1,1 @@
-runtime! indent/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/indent/jsx.vim
+++ b/after/indent/jsx.vim
@@ -1,1 +1,1 @@
-runtime! indent/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -1,1 +1,1 @@
-runtime! indent/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/indent/typescriptreact.vim
+++ b/after/indent/typescriptreact.vim
@@ -1,1 +1,1 @@
-runtime! indent/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/syntax/javascriptreact.vim
+++ b/after/syntax/javascriptreact.vim
@@ -1,1 +1,1 @@
-runtime! syntax/javascript.vim
+source <sfile>:p:h/javascript.vim

--- a/after/syntax/typescript.vim
+++ b/after/syntax/typescript.vim
@@ -1,4 +1,4 @@
-runtime! syntax/javascript.vim
+source <sfile>:p:h/javascript.vim
 
 " define custom API section, that contains typescript annotations
 " this is structurally similar to `jsFuncCall`, but allows type

--- a/after/syntax/typescriptreact.vim
+++ b/after/syntax/typescriptreact.vim
@@ -1,1 +1,1 @@
-runtime! syntax/typescript.vim
+source <sfile>:p:h/typescript.vim


### PR DESCRIPTION
Previously, we were loading all known javascript files for anything not specifically javascript. Now, we're only referencing the specific plugin files we intend to reference for syntax highlighting and indentation in styled-components. This should resolve any conflicts with other plugins.

* Using `source` instead of `runtime!` (which pulls in every known javascript.vim file for after/indent/ftplugin/etc).
* Resolves #73
* Resolves #74 
* Resolves #75
* Resolves #76